### PR TITLE
Fixed hardcoded executable location

### DIFF
--- a/netrek-client-cow.desktop
+++ b/netrek-client-cow.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Netrek
-Exec=/usr/games/netrek-client-cow
+Exec=netrek-client-cow
 Icon=/usr/share/pixmaps/netrek-client-cow/icon.png
 StartupNotify=false
 Terminal=false


### PR DESCRIPTION
https://github.com/quozl/netrek-client-cow/blob/d4b7ce940ac6e64f7735fef67e67b12302bbf373/INSTALL#L103 is configurable so it shouldn't be hardcoded here.